### PR TITLE
Used hard-coded ip address for Docker containers - to be altered

### DIFF
--- a/thaiSilk/appointment/services/api.php
+++ b/thaiSilk/appointment/services/api.php
@@ -5,7 +5,7 @@
 	
 		public $data = "";
 		
-		const DB_SERVER = "missusw.db.11449081.hostedresource.com";
+		const DB_SERVER = "172.17.0.2";
 		const DB_USER = "missusw";
 		const DB_PASSWORD = "two@AT1me";
 		const DB = "missusw";

--- a/thaiSilk/appointment/services/config.php
+++ b/thaiSilk/appointment/services/config.php
@@ -4,7 +4,7 @@
  */
 define('DB_USERNAME', "missusw");
 define('DB_PASSWORD', "two@AT1me");
-define('DB_HOST', "missusw.db.11449081.hostedresource.com");
+define('DB_HOST', "172.17.0.2");
 define('DB_NAME', "missusw");
 
 ?>


### PR DESCRIPTION
Hi

I altered the DB_HOST / DB_SERVER php constants to use IP Addresses for Docker containers.  Eventually these will have to be replaced, using references to environment variable from the host OS.

Mark